### PR TITLE
Solve bug related with program not releasing resources on closing whi…

### DIFF
--- a/Client/src/presenter/presenter.cpp
+++ b/Client/src/presenter/presenter.cpp
@@ -178,6 +178,9 @@ void Presenter::sync_ui_inputs()
 
 void Presenter::close_program()
 {
+	//Assure we stop tracking loop.
+	run = false;
 	// Assure the camera is released (some cameras have a "recording LED" which can be annoying to have on)
-	camera->stop_camera(); 
+	camera->stop_camera();
+	// The remaining resources will be released on destructor.
 }


### PR DESCRIPTION
As reported on https://github.com/AIRLegend/aitracker/issues/9, this could keep the program running or crashing.

Error reproduction: 

1. User starts tracking
2. User closes the program

Effect: 
- Tested before, the program crashed but closed (using PS3 camera).
- It could be the case that it didn't release all resources (for example the UDP socket), which could cause the task manager to show it as running.

Now:
The program exits as expected.

![Untitled](https://user-images.githubusercontent.com/9653892/89726787-c1971700-da1e-11ea-8573-5b64409686f0.png)
